### PR TITLE
Support python3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: python
-sudo: false
+dist: xenial
 python:
     - 2.7
     - 3.4
     - 3.5
     - 3.6
-    - pypy
-    - pypy3
+    - 3.7
+    - pypy2.7-5.10.0
+    - pypy3.5
 install:
     - pip install -U pip setuptools
     - pip install -U coverage coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,17 @@
 language: python
-dist: xenial
 python:
     - 2.7
     - 3.4
     - 3.5
     - 3.6
-    - 3.7
-    - pypy2.7-5.10.0
-    - pypy3.5
+    - pypy
+    - pypy3
+
+matrix:
+    include:
+        - python: "3.7"
+          dist: xenial
+
 install:
     - pip install -U pip setuptools
     - pip install -U coverage coveralls

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@
 ==================
 
 - Adapt tests to `zope.configuration >= 4.2`.
+- Add support for Python 3.7.
 
 
 3.0.0 (2017-10-18)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
  CHANGES
 =========
 
-3.0.1 (unreleased)
+3.1.0 (unreleased)
 ==================
 
 - Adapt tests to `zope.configuration >= 4.2`.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 3.0.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Adapt tests to `zope.configuration >= 4.2`.
 
 
 3.0.0 (2017-10-18)

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Programming Language :: Python',

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
         'setuptools',
         'zope.browserpage',
         'zope.component',
-        'zope.configuration',
+        'zope.configuration >= 4.2.0',
         'zope.interface',
         'zope.pagetemplate',
         'zope.publisher',

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ TESTS_REQUIRE = CHAMELEON_REQUIRES + [
 
 setup(
     name='z3c.template',
-    version='3.0.1.dev0',
+    version='3.1.0.dev0',
     author="Roger Ineichen and the Zope Community",
     author_email="zope-dev@zope.org",
     description="A package implementing advanced Page Template patterns.",

--- a/src/z3c/template/tests.py
+++ b/src/z3c/template/tests.py
@@ -75,9 +75,14 @@ class TestMacro(unittest.TestCase):
         macro.wrapper = lambda **kwargs: None
 
         macro()
-        self.assertEqual('text/html', request.response.getHeader("Content-Type"))
+        self.assertEqual(
+            'text/html', request.response.getHeader("Content-Type"))
+
 
 class TestBoundViewTemplate(unittest.TestCase):
+
+    assertRaisesRegex = getattr(unittest.TestCase, 'assertRaisesRegex',
+                                unittest.TestCase.assertRaisesRegexp)
 
     def test_call_no__self__uses_first_arg(self):
         def im_func(*args):
@@ -91,12 +96,7 @@ class TestBoundViewTemplate(unittest.TestCase):
 
     def test_cant_setattr(self):
         bound = z3c.template.template.BoundViewTemplate(None, None)
-        try:
-            raisesRegex = self.assertRaisesRegex
-        except AttributeError:
-            # We are still with python 2.7 here, remove if not supported
-            raisesRegex = self.assertRaisesRegexp
-        with raisesRegex(AttributeError, "Can't set attribute"):
+        with self.assertRaisesRegex(AttributeError, "Can't set attribute"):
             setattr(bound, 'im_func', 42)
 
     def test_repr(self):

--- a/src/z3c/template/tests.py
+++ b/src/z3c/template/tests.py
@@ -91,8 +91,12 @@ class TestBoundViewTemplate(unittest.TestCase):
 
     def test_cant_setattr(self):
         bound = z3c.template.template.BoundViewTemplate(None, None)
-        with self.assertRaisesRegexp(AttributeError,
-                                     "Can't set attribute"):
+        try:
+            raisesRegex = self.assertRaisesRegex
+        except AttributeError:
+            # We are still with python 2.7 here, remove if not supported
+            raisesRegex = self.assertRaisesRegexp
+        with raisesRegex(AttributeError, "Can't set attribute"):
             setattr(bound, 'im_func', 42)
 
     def test_repr(self):

--- a/src/z3c/template/tests.py
+++ b/src/z3c/template/tests.py
@@ -15,23 +15,15 @@
 """
 import doctest
 import itertools
-import re
 import unittest
 
 from zope.configuration import xmlconfig
 from zope.component import testing
-from zope.testing import renormalizing
 
 import z3c.pt
 import z3c.ptcompat
 import z3c.template.template
 
-checker = renormalizing.RENormalizing([
-    # Python 3 adds module name to exceptions;
-    # The output of this one is too complex for IGNORE_EXCEPTION_MODULE_IN_PYTHON2
-    (re.compile('zope.configuration.xmlconfig.ZopeXMLConfigurationError'),
-     'ZopeXMLConfigurationError'),
-])
 
 
 def setUp(test):
@@ -125,16 +117,14 @@ def test_suite():
             setUp=setUp, tearDown=tearDown,
             optionflags=(doctest.NORMALIZE_WHITESPACE
                          | doctest.ELLIPSIS
-                         | renormalizing.IGNORE_EXCEPTION_MODULE_IN_PYTHON2),
-            checker=checker,
+                         | doctest.IGNORE_EXCEPTION_DETAIL),
         ),
         doctest.DocFileSuite(
             'zcml.rst',
             setUp=setUp, tearDown=tearDown,
             optionflags=(doctest.NORMALIZE_WHITESPACE
                          | doctest.ELLIPSIS
-                         | renormalizing.IGNORE_EXCEPTION_MODULE_IN_PYTHON2),
-            checker=checker,
+                         | doctest.IGNORE_EXCEPTION_DETAIL),
         ),
     ) for setUp in setups)
     doctests = list(itertools.chain(*doctests))

--- a/src/z3c/template/zcml.rst
+++ b/src/z3c/template/zcml.rst
@@ -93,8 +93,8 @@ get an error:
   ... """, context=context)
   Traceback (most recent call last):
   ...
-  ZopeXMLConfigurationError: File "<string>", line 4.2-7.8
-      ConfigurationError: ('No such file', '...this_file_does_not_exist')
+  ConfigurationError: ('No such file', '...this_file_does_not_exist')
+  File "<string>", line 4.2-7.8
 
 Layout template
 ===============

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,py34,py35,py36,pypy,pypy3,coverage
+    py27,py34,py35,py36,py37,pypy,pypy3,coverage
 
 [testenv]
 commands =
@@ -11,7 +11,7 @@ deps =
 [testenv:coverage]
 usedevelop = true
 basepython =
-    python2.7
+    python3.7
 commands =
     coverage run -m zope.testrunner --test-path=src []
     coverage report --fail-under=100


### PR DESCRIPTION
This PR adds Python 3.7 support. In adapts tests to the new way exceptions are handled in `zope.configuration >=  4.2.`