### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
  CHANGES
 =========
 
-4.2 (unreleased)
+5.0 (unreleased)
 ================
 
 - Nothing changed yet.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 5.0 (unreleased)
 ================
 
-- Nothing changed yet.
+- Drop support for ``pkg_resources`` namespace and replace it with PEP 420 native namespace. Caution: This change requires to switch all packages in the  namespace of the package to versions using a PEP 420 namespace.
 
 
 4.1 (2025-04-04)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@
 """
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -34,7 +33,7 @@ CHAMELEON_REQUIRES = [
 
 TESTS_REQUIRE = CHAMELEON_REQUIRES + [
     'zope.testing',
-    'zope.testrunner',
+    'zope.testrunner >= 6.4',
     'zope.traversing',
 ]
 
@@ -75,9 +74,6 @@ setup(
         'Framework :: Zope :: 3',
     ],
     url='https://github.com/zopefoundation/z3c.template',
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
-    namespace_packages=['z3c'],
     python_requires='>=3.9',
     extras_require={
         'test': TESTS_REQUIRE,

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ TESTS_REQUIRE = CHAMELEON_REQUIRES + [
 
 setup(
     name='z3c.template',
-    version='4.2.dev0',
+    version='5.0.dev0',
     author="Roger Ineichen and the Zope Community",
     author_email="zope-dev@zope.dev",
     description="A package implementing advanced Page Template patterns.",

--- a/src/z3c/__init__.py
+++ b/src/z3c/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Drop support for ``pkg_resources`` namespace and replace it with PEP 420 native namespace. Caution: This change requires to switch all packages in the  namespace of the package to versions using a PEP 420 namespace.**
- **Switch to PEP 420 native namespace.**
